### PR TITLE
Hide the window title bar and border unless the app is focused

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Upload files
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: UltraWideScreenShare2-${{ matrix.rid }}
         path: ${{ env.Project_Dir }}\bin\${{ matrix.configuration }}\net6.0-windows\${{ matrix.rid }}\publish\

--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,6 @@ __pycache__/
 appsettings.local.json
 .vscode/
 *.DS_Store
+
+# Claude
+.claude/

--- a/UltraWideScreenShare.WinForms/MainWindow.cs
+++ b/UltraWideScreenShare.WinForms/MainWindow.cs
@@ -14,6 +14,7 @@ namespace UltraWideScreenShare.WinForms
         private Color _frameColor = Color.FromArgb(255, 53, 89, 224); //#3559E0
         const int _borderWidth = 6;
         private bool _showMagnifierScheduled = true;
+        private bool _isFocused = true;
         public MainWindow()
         {
             InitializeComponent();
@@ -27,6 +28,24 @@ namespace UltraWideScreenShare.WinForms
             base.OnCreateControl();
 
             this.InitializeMainWindowStyle();
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            base.OnActivated(e);
+            _isFocused = true;
+            TitleBar.Visible = true;
+            Padding = new Padding(_borderWidth, _borderWidth, _borderWidth, _borderWidth);
+            Invalidate();
+        }
+
+        protected override void OnDeactivate(EventArgs e)
+        {
+            base.OnDeactivate(e);
+            _isFocused = false;
+            TitleBar.Visible = false;
+            Padding = new Padding(0);
+            Invalidate();
         }
 
         private void InitializePaddingsForBorders()
@@ -101,19 +120,22 @@ namespace UltraWideScreenShare.WinForms
 
             base.WndProc(ref m);
 
-            if (message == WM_NCHITTEST)
+            if (message == WM_NCHITTEST && _isFocused)
             {
                 this.TryResize(ref m, _borderWidth);
             }
         }
 
         private void MainWindow_Paint(object sender, PaintEventArgs e)
-        { 
-            ControlPaint.DrawBorder(e.Graphics, ClientRectangle,
-                _frameColor, _borderWidth, ButtonBorderStyle.Solid,
-                _frameColor, _borderWidth, ButtonBorderStyle.Solid,
-                _frameColor, _borderWidth, ButtonBorderStyle.Solid,
-                _frameColor, _borderWidth, ButtonBorderStyle.Solid);
+        {
+            if (_isFocused)
+            {
+                ControlPaint.DrawBorder(e.Graphics, ClientRectangle,
+                    _frameColor, _borderWidth, ButtonBorderStyle.Solid,
+                    _frameColor, _borderWidth, ButtonBorderStyle.Solid,
+                    _frameColor, _borderWidth, ButtonBorderStyle.Solid,
+                    _frameColor, _borderWidth, ButtonBorderStyle.Solid);
+            }
         }
 
         private void TitleBar_Paint(object sender, PaintEventArgs e)


### PR DESCRIPTION
Thanks for the app, I prefer it not to be visible when sharing so this patch hides the border and window title unless you focus the app with alt-tab or clicking on it in the task bar.   Teams shows a red border around the window locally anyways so you can see the area being shared.